### PR TITLE
#56: Hide error page from index

### DIFF
--- a/src/SIKA/Models/Posts/PostRoot.cs
+++ b/src/SIKA/Models/Posts/PostRoot.cs
@@ -35,6 +35,7 @@ public class PostRoot(FileSystemInfo? parent, FileSystemInfo current) : PostRoot
     {
         return Children
              ?.Order(PostTreeComparer.Default)
+              .Where(child => child is not PostLeaf leaf || !leaf.Info.Name.Equals("error.md", StringComparison.OrdinalIgnoreCase))
               .Select(child => child.GetHtml())
               .Aggregate(new StringBuilder(), (builder, html) => builder.AppendLine(html?.ToString()))
               .ToString()


### PR DESCRIPTION
Hide error page from index. Ref #56.

## Work List

- src/SIKA/Models/Posts/PostRoot.cs: Hide error page from index