### PR TITLE
:bug: #79: Use `Raw` rather than `Html.Raw` in razor template

### DIFF
--- a/src/sika/Resources/default.cshtml
+++ b/src/sika/Resources/default.cshtml
@@ -69,7 +69,7 @@ along with SIKA.  If not, see <https://www.gnu.org/licenses/>.
 
     <!-- TREE VIEW -->
     <ul id="tree-view">
-        @Html.Raw(Model.PostTree.GetHtml())
+        @Raw(Model.PostTree.GetHtml())
     </ul>
 </nav>
 
@@ -95,7 +95,7 @@ along with SIKA.  If not, see <https://www.gnu.org/licenses/>.
 </header>
 
 <main id="article-main" class="markdown-body">
-@Html.Raw(Model.Html)
+@Raw(Model.Html)
 </main>
 
 </body>


### PR DESCRIPTION
Make razor template to use `Raw` rather than `Html.Raw`.
Issue have gone.

See also #79