### PR TITLE
:bug: #85:  Ensure base directory of leaf-data

### DIFF
--- a/src/sika.core/Components/Abstract/ILinker.cs
+++ b/src/sika.core/Components/Abstract/ILinker.cs
@@ -17,5 +17,9 @@ namespace sika.core.Components.Abstract;
 
 public interface ILinker
 {
+    public bool IsSynchronous { get; }
+    
+    public bool CanExecute(PageTree tree);
+    
     public Task CompileAsync(PageTree tree);
 }

--- a/src/sika.core/Components/FileSystemWriter.cs
+++ b/src/sika.core/Components/FileSystemWriter.cs
@@ -21,6 +21,10 @@ namespace sika.core.Components;
 
 public class FileSystemWriter(Project project) : ILinker
 {
+    public bool IsSynchronous => true;
+    
+    public bool CanExecute(PageTree tree) => true;
+    
     public async Task CompileAsync(PageTree tree)
     {
         var fullname = Path.Combine(project.Info.SiteDirectory, tree.GetFullPath());

--- a/src/sika.core/Components/GoogleSitemapLinker.cs
+++ b/src/sika.core/Components/GoogleSitemapLinker.cs
@@ -32,6 +32,13 @@ public class GoogleSitemapLinker(Project project) : ILinker, IDisposable
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + urlSet.ToString(SaveOptions.OmitDuplicateNamespaces));
     }
 
+    public bool IsSynchronous => false;
+    
+    public bool CanExecute(PageTree tree)
+    {
+        return tree.Content is PageLeafData;
+    }
+
     public Task CompileAsync(PageTree tree)
     {
         var loc     = project.Info.RootUri + tree.GetFullPath();

--- a/src/sika.core/Components/RazorLinker.cs
+++ b/src/sika.core/Components/RazorLinker.cs
@@ -64,6 +64,13 @@ public class RazorLinker : ILinker
             .Build();
     }
 
+    public bool IsSynchronous => false;
+
+    public bool CanExecute(PageTree tree)
+    {
+        return tree.Content is PageLeafData;
+    }
+
     public async Task CompileAsync(PageTree tree)
     {
         var data = (PageLeafData)tree.Content;

--- a/src/sika.core/Components/YamlPreprocessor.cs
+++ b/src/sika.core/Components/YamlPreprocessor.cs
@@ -30,6 +30,13 @@ public class YamlPreprocessor : ILinker
         .UseYamlFrontMatter()
         .Build();
 
+    public bool IsSynchronous => false;
+
+    public bool CanExecute(PageTree tree)
+    {
+        return tree.Content is PageLeafData;
+    }
+
     public Task CompileAsync(PageTree tree)
     {
         var leafData = (PageLeafData)tree.Content;

--- a/src/sika/sika.csproj
+++ b/src/sika/sika.csproj
@@ -7,7 +7,7 @@
         <Nullable>enable</Nullable>
         <PreserveCompilationContext>true</PreserveCompilationContext>
 
-        <AssemblyVersion>3.0.0</AssemblyVersion>
+        <AssemblyVersion>3.0.1</AssemblyVersion>
         
         <PackAsTool>true</PackAsTool>
         <ToolCommandName>sika</ToolCommandName>


### PR DESCRIPTION
Ensure base directory of leaf-data

- Let linker select its traversing behaviour, whether synchronous or asynchronous.
- Conserve order of file/directories in level-order to create base directory before its children