### PR TITLE
:bug: #89: Escape urls in href

### DIFF
--- a/src/sika/sika.csproj
+++ b/src/sika/sika.csproj
@@ -7,7 +7,7 @@
         <Nullable>enable</Nullable>
         <PreserveCompilationContext>true</PreserveCompilationContext>
 
-        <AssemblyVersion>3.0.2</AssemblyVersion>
+        <AssemblyVersion>3.0.3</AssemblyVersion>
         
         <PackAsTool>true</PackAsTool>
         <ToolCommandName>sika</ToolCommandName>


### PR DESCRIPTION
- Escape urls in href
- Add escape option to `PageTree.GetFullPath`

See also #89