### PR TITLE
:bug: #95: Replace whitespaces to plus-sign to handle url-encoded hrefs

### DIFF
--- a/src/sika.core/Components/FileSystemWriter.cs
+++ b/src/sika.core/Components/FileSystemWriter.cs
@@ -38,7 +38,9 @@ public class FileSystemWriter : ILinker, IDisposable
 
     public async Task CompileAsync(PageTree tree)
     {
-        var fullname = Path.Combine(_project.Info.SiteDirectory, tree.GetFullPath());
+        var path = tree.GetFullPath().Replace(' ', '+');
+        
+        var fullname = Path.Combine(_project.Info.SiteDirectory, path);
 
         if (tree.Content is PageLeafData leaf)
         {

--- a/src/sika/sika.csproj
+++ b/src/sika/sika.csproj
@@ -7,7 +7,7 @@
         <Nullable>enable</Nullable>
         <PreserveCompilationContext>true</PreserveCompilationContext>
 
-        <AssemblyVersion>3.2.0</AssemblyVersion>
+        <AssemblyVersion>3.2.1</AssemblyVersion>
         
         <PackAsTool>true</PackAsTool>
         <ToolCommandName>sika</ToolCommandName>


### PR DESCRIPTION
### Target

- HRefs use url-encoded path for posts - whose whitespaces(` `) are replaced with plus-sign(`+`)
- But, because file-system-writer does nothing to encode paths, `%20` is required, not plus-sign(`+`).

### Patches

- Replace whitespace to plus-sign when writing to file-system

See also #95 